### PR TITLE
Update NetworkManager to enable VPN connections

### DIFF
--- a/NetworkManager.service.d/hardening.conf
+++ b/NetworkManager.service.d/hardening.conf
@@ -17,7 +17,7 @@ RestrictAddressFamilies=AF_INET AF_INET6 AF_NETLINK AF_PACKET AF_UNIX
 #  these settings with either CapabilityBoundingSet=~CAP_SYS_ADMIN or
 #  SystemCallFilter=~@mount.
 
-ProtectHome=yes
+#♠ProtectHome= need to be able to access VPN cert that can be saved in /root or in ~/
 ProtectSystem=strict
 ProtectProc=invisible
 ReadWritePaths=/etc -/proc/sys/net -/var/lib/NetworkManager/
@@ -35,7 +35,8 @@ PrivateTmp=yes
 ###########
 
 PrivateDevices=yes
-# DeviceAllow=/dev/exampledevice
+DeviceAllow=/dev/net/tun
+DeviceAllow=/dev/net/tap
 
 ##########
 # Kernel #
@@ -53,7 +54,7 @@ CapabilityBoundingSet=~CAP_SYS_ADMIN CAP_SETUID CAP_SETGID CAP_SYS_CHROOT
 # AmbientCapabilities= service runs as root
 NoNewPrivileges=yes
 ProtectHostname=yes
-ProtectClock=yes
+#ProtectClock= required if we want to use a VPN
 ProtectControlGroups=yes
 RestrictNamespaces=yes
 LockPersonality=yes


### PR DESCRIPTION
This is a modified version tested on Manjaro to enable a secure OpenVPN connection based on /dev/net/tun I also added what may be needed for a tap connection but untested It may still be possible to use PrivateHome by allowing specific certs location but they may depends on configurations/distro/version so it may be too difficult (use tmpfs instead?)